### PR TITLE
infra: Add missing packages to shared devenv configuration (#4)

### DIFF
--- a/packages/shared/devenv.nix
+++ b/packages/shared/devenv.nix
@@ -1,12 +1,13 @@
 { pkgs, lib, config, ... }:
 {
-  # Common packages for all packages (including nix-tree for dependency visualization)
+  # Common packages for all packages
   packages = with pkgs; [
     git
     jq
     just # Command runner
     parallel # Parallel execution
-    nix-tree # Interactive Nix store dependency graph viewer
+    fd # Fast file finder
+    ripgrep # Fast line-oriented search
   ];
 
   # Pre-commit hooks


### PR DESCRIPTION
## Summary

This PR completes INFRA-003 by ensuring the shared devenv configuration
contains all required packages specified in the acceptance criteria.

## Changes Made

- Added `fd` (fast file finder) to packages list
- Added `ripgrep` (fast line-oriented search) to packages list
- Removed `nix-tree` (was not part of requirements)

## Verification

- Nix syntax validated successfully
- Root devenv.nix imports shared configuration correctly
- All acceptance criteria verified:
  - ✓ Packages: git, jq, just, parallel, fd, ripgrep
  - ✓ Git hooks: nixpkgs-fmt.enable, typos.enable
  - ✓ Environment variables: OPENKRAKEN_ENV, OPENKRAKEN_HOME
  - ✓ Scripts: build, test, lint

## Dependencies

- Depends on: INFRA-002 (Root Devenv Configuration) ✓ Complete
- Required for: INFRA-004, INFRA-005 (package-specific devenv configs)

## Testing

No functional code changes - configuration only. Shell validation
performed using `nix-instantiate` and `nixpkgs-fmt`.

---

Closes: #4