### PR TITLE
feat(infra): Cross-Language Build Coordination (INFRA-006)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,91 @@
+# OpenKraken Cross-Language Build Coordination
+# Coordinates TypeScript/Bun orchestrator with Go egress-gateway
+
+# Configuration variables
+BIN_DIR := "bin"
+ORCHESTRATOR_DIR := "packages/orchestrator"
+EGRESS_GATEWAY_DIR := "packages/egress-gateway"
+ORCHESTRATOR_BINARY := BIN_DIR / "openkraken"
+EGRESS_GATEWAY_BINARY := BIN_DIR / "egress-gateway"
+
+# Default recipe - show available tasks
+default:
+    @echo "OpenKraken Build System"
+    @echo ""
+    @echo "Available recipes:"
+    @just --list
+
+# Build all packages
+build: build-orchestrator build-egress-gateway
+    @echo "Build complete - binaries in /bin/"
+
+# Build orchestrator (TypeScript/Bun)
+build-orchestrator:
+    @echo "Building orchestrator..."
+    mkdir -p {{BIN_DIR}}
+    cd {{ORCHESTRATOR_DIR}} && bun build --compile --outfile ../../bin/openkraken
+    @echo "Orchestrator built: {{ORCHESTRATOR_BINARY}}"
+
+# Build egress-gateway (Go)
+build-egress-gateway:
+    @echo "Building egress-gateway..."
+    mkdir -p {{BIN_DIR}}
+    cd {{EGRESS_GATEWAY_DIR}} && go build -o ../../bin/egress-gateway ./src
+    @echo "Egress gateway built: {{EGRESS_GATEWAY_BINARY}}"
+
+# Test all packages
+test: test-orchestrator test-egress-gateway
+    @echo "All tests passed"
+
+# Test orchestrator
+test-orchestrator:
+    @echo "Running orchestrator tests..."
+    cd {{ORCHESTRATOR_DIR}} && bun test
+
+# Test egress-gateway
+test-egress-gateway:
+    @echo "Running egress-gateway tests..."
+    cd {{EGRESS_GATEWAY_DIR}} && go test ./...
+
+# Lint all packages
+lint: lint-orchestrator lint-egress-gateway
+    @echo "All linting passed"
+
+# Lint orchestrator
+lint-orchestrator:
+    @echo "Linting orchestrator..."
+    cd {{ORCHESTRATOR_DIR}} && biome lint src/
+
+# Lint egress-gateway
+lint-egress-gateway:
+    @echo "Linting egress-gateway..."
+    cd {{EGRESS_GATEWAY_DIR}} && go vet ./...
+
+# Clean all build artifacts
+clean:
+    @echo "Cleaning build artifacts..."
+    rm -rf {{BIN_DIR}}
+    @echo "Clean complete"
+
+# Build and verify binaries exist
+build-verified: build
+    @echo "Verifying build outputs..."
+    if [ ! -f "{{ORCHESTRATOR_BINARY}}" ]; then \
+        echo "Error: Orchestrator binary not found: {{ORCHESTRATOR_BINARY}}"; \
+        exit 1; \
+    fi
+    if [ ! -f "{{EGRESS_GATEWAY_BINARY}}" ]; then \
+        echo "Error: Egress gateway binary not found: {{EGRESS_GATEWAY_BINARY}}"; \
+        exit 1; \
+    fi
+    @echo "Build verification passed"
+    @echo "Binaries:"
+    ls -lh {{ORCHESTRATOR_BINARY}} {{EGRESS_GATEWAY_BINARY}}
+
+# Show build information
+info:
+    @echo "OpenKraken Build Configuration"
+    @echo "=============================="
+    @echo "Bin Directory: {{BIN_DIR}}"
+    @echo "Orchestrator: {{ORCHESTRATOR_DIR}} -> {{ORCHESTRATOR_BINARY}}"
+    @echo "Egress Gateway: {{EGRESS_GATEWAY_DIR}} -> {{EGRESS_GATEWAY_BINARY}}"


### PR DESCRIPTION
## Summary

Create root `Justfile` with tasks for building both TypeScript (Bun) and Go packages, coordinating output paths and ensuring consistent build experience.

## Changes

- Created `/Justfile` with 13 recipes:
  - `build`: Builds both orchestrator and egress-gateway
  - `build-orchestrator`: Bun build with `--compile` flag to `/bin/openkraken`
  - `build-egress-gateway`: Go build to `/bin/egress-gateway`
  - `test`: Runs tests for both packages
  - `lint`: Runs linters for both packages (biome, go vet)
  - `clean`: Removes `/bin/` directory contents
  - `build-verified`: Build + verification of binary existence
  - `info`: Display build configuration

## Acceptance Criteria Met

- ✅ `just build` orchestrates both packages with correct commands
- ✅ `just test` runs tests for both packages
- ✅ `just lint` runs linters for both packages
- ✅ `just clean` removes /bin/ directory contents
- ✅ Binaries output to `/bin/` directory
- ✅ `/bin/` already gitignored in .gitignore

## Dependencies

- INFRA-004: Orchestrator Devenv Configuration (complete)
- INFRA-005: Egress Gateway Devenv Configuration (complete)

## Testing

Verified via dry-run execution:
```
just --dry-run build
just --dry-run lint
just --dry-run test
```

Commands execute correctly with expected syntax. Build execution requires devenv environment for Bun/Go runtimes.

---

Closes: #7