### PR TITLE
infra: Direnv Auto-Activation with watch_file directives (#9)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -10,3 +10,8 @@ eval "$(devenv direnvrc)"
 #
 # Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
 use devenv
+
+# Watch devenv configuration files for automatic reload
+watch_file "devenv.nix"
+watch_file "devenv.yaml"
+watch_file "devenv.lock"


### PR DESCRIPTION
## Summary

Adds `watch_file` directives to the root `.envrc` file to enable automatic
reload when devenv configuration files are modified.

## Changes

- Added `watch_file "devenv.nix"` directive
- Added `watch_file "devenv.yaml"` directive
- Added `watch_file "devenv.lock"` directive

## Acceptance Criteria Met

- `.envrc` contains `use devenv` directive (pre-existing)
- `watch_file` monitors: devenv.nix, devenv.yaml, devenv.lock
- Modifying watched files triggers automatic reload
- `direnv status` shows "Loaded" and "Allowed"

## Technical Details

The implementation follows the direnv stdlib pattern for monitoring files.
When any of the watched devenv configuration files change, direnv will
automatically reload the environment on the next prompt.

---

Closes: #9