### PR TITLE
[INFRA-011] Service Generation (systemd/launchd)

### DIFF
--- a/nix/darwin-modules/openkraken.nix
+++ b/nix/darwin-modules/openkraken.nix
@@ -34,8 +34,16 @@ in
 
       dataDir = mkOption {
         type = types.path;
-        default = "/var/lib/openkraken";
+        default = "%h/Library/Application Support/Openkraken";
+        defaultText = ''"%h/Library/Application Support/Openkraken"'';
         description = "Data directory for OpenKraken";
+      };
+
+      configDir = mkOption {
+        type = types.path;
+        default = "%h/Library/Application Support/Openkraken";
+        defaultText = ''"%h/Library/Application Support/Openkraken"'';
+        description = "Configuration directory for OpenKraken";
       };
     };
 
@@ -66,7 +74,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    launchd.daemons.openkraken-orchestrator = mkIf cfg.orchestrator.enable {
+    launchd.user.agents.openkraken-orchestrator = mkIf cfg.orchestrator.enable {
       description = "OpenKraken Agent Orchestrator";
       serviceConfig = {
         Label = "com.openkraken.orchestrator";
@@ -77,21 +85,23 @@ in
         StandardErrorPath = "/var/log/openkraken/orchestrator.err";
         EnvironmentVariables = {
           OPENKRAKEN_HOME = cfg.orchestrator.dataDir;
+          OPENKRAKEN_CONFIG = "${cfg.orchestrator.configDir}/config.yaml";
           ORCHESTRATOR_PORT = toString cfg.orchestrator.port;
         };
       };
     };
 
-    launchd.daemons.openkraken-gateway = mkIf cfg.gateway.enable {
+    launchd.user.agents.openkraken-egress-gateway = mkIf cfg.gateway.enable {
       description = "OpenKraken Egress Gateway";
       serviceConfig = {
-        Label = "com.openkraken.gateway";
+        Label = "com.openkraken.egress-gateway";
         ProgramArguments = [ "${cfg.gateway.package}/bin/egress-gateway" ];
         RunAtLoad = true;
         KeepAlive = true;
         StandardOutPath = "/var/log/openkraken/gateway.log";
         StandardErrorPath = "/var/log/openkraken/gateway.err";
         EnvironmentVariables = {
+          OPENKRAKEN_CONFIG = "${cfg.orchestrator.configDir}/config.yaml";
           EGRESS_GATEWAY_PORT = toString cfg.gateway.port;
           EGRESS_SOCKET_PATH = cfg.gateway.socketPath;
         };

--- a/nix/nixos-modules/openkraken.nix
+++ b/nix/nixos-modules/openkraken.nix
@@ -31,11 +31,16 @@ in
         default = 3000;
         description = "Orchestrator port";
       };
-
       dataDir = mkOption {
         type = types.path;
         default = "/var/lib/openkraken";
         description = "Data directory for OpenKraken";
+      };
+
+      configDir = mkOption {
+        type = types.path;
+        default = "/etc/openkraken";
+        description = "Configuration directory for OpenKraken";
       };
     };
 
@@ -81,6 +86,7 @@ in
         RuntimeDirectoryMode = "0755";
         Environment = [
           "OPENKRAKEN_HOME=${cfg.orchestrator.dataDir}"
+          "OPENKRAKEN_CONFIG=${cfg.orchestrator.configDir}/config.yaml"
           "ORCHESTRATOR_PORT=${toString cfg.orchestrator.port}"
         ];
         ExecStart = "${cfg.orchestrator.package}/bin/openkraken";
@@ -89,7 +95,7 @@ in
       };
     };
 
-    systemd.services.openkraken-gateway = mkIf cfg.gateway.enable {
+    systemd.services.openkraken-egress-gateway = mkIf cfg.gateway.enable {
       description = "OpenKraken Egress Gateway";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
@@ -103,6 +109,7 @@ in
         RuntimeDirectory = "openkraken";
         RuntimeDirectoryMode = "0755";
         Environment = [
+          "OPENKRAKEN_CONFIG=${cfg.orchestrator.configDir}/config.yaml"
           "EGRESS_GATEWAY_PORT=${toString cfg.gateway.port}"
           "EGRESS_SOCKET_PATH=${cfg.gateway.socketPath}"
         ];


### PR DESCRIPTION
## Summary

Implements Nix modules for generating systemd (Linux) and launchd (macOS) service configurations from unified specification, automating service installation and lifecycle management.

## Changes

### NixOS Module (`nix/nixos-modules/openkraken.nix`)
- Generates `openkraken-orchestrator.service` and `openkraken-egress-gateway.service`
- Configures user/group, environment variables, restart policies
- Adds `configDir` option (default: `/etc/openkraken`)

### Darwin Module (`nix/darwin-modules/openkraken.nix`)
- Generates user-level LaunchAgents at `~/Library/LaunchAgents/`
- Uses `launchd.user.agents` for per-user service management
- Adds `configDir` option with `%h` for home directory expansion
- Adds `dataDir` option defaulting to `~/Library/Application Support/Openkraken`

### Environment Variables
Both modules now set:
- `OPENKRAKEN_HOME` - data directory path
- `OPENKRAKEN_CONFIG` - configuration file path (`<dir>/config.yaml`)
- Platform-specific variables (`ORCHESTRATOR_PORT`, `EGRESS_GATEWAY_PORT`, etc.)

## Acceptance Criteria

| Platform | Service File | Status |
|----------|--------------|--------|
| Linux | `/etc/systemd/system/openkraken-orchestrator.service` | ✓ |
| Linux | `/etc/systemd/system/openkraken-egress-gateway.service` | ✓ |
| macOS | `~/Library/LaunchAgents/com.openkraken.orchestrator.plist` | ✓ |
| macOS | `~/Library/LaunchAgents/com.openkraken.egress-gateway.plist` | ✓ |

## Verification

```
nix flake check --all-systems
```

Closes: #12