### PR TITLE
chore(INFRA-012): add CUE configuration schema

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -139,10 +139,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1769939035,
+        "lastModified": 1770726378,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
+        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
         "type": "github"
       },
       "original": {
@@ -248,10 +248,10 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1770464364,
+        "lastModified": 1771043024,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
+        "rev": "3aadb7ca9eac2891d52a9dec199d9580a6e2bf44",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,20 @@
           };
         };
 
+        # Nix checks for validation
+        checks = {
+          # Validate example config against CUE schema
+          config-validation = pkgs.runCommand "config-validation"
+            {
+              nativeBuildInputs = [ pkgs.cue ];
+            } ''
+            mkdir -p $out
+            cue vet -c -d '#Config' ${./nix/schema/config.cue} ${./nix/schema/example.config.yaml}
+            echo "Validation passed!"
+            touch $out/success
+          '';
+        };
+
         devShells.default = pkgs.callPackage ./nix/shell.nix {
           inherit devenv;
         };

--- a/nix/schema/config.cue
+++ b/nix/schema/config.cue
@@ -1,0 +1,338 @@
+package config
+
+import "net"
+
+// OpenKraken Configuration Schema v1.0
+// This schema validates config.yaml against the configuration specification
+// defined in TechSpec Section 6.3.
+//
+// Usage:
+//   cue vet -c nix/schema/config.cue config.yaml
+//
+// The schema enforces:
+// - Required fields and their types
+// - Value constraints (ranges, enums)
+// - Structural validation
+
+#Config: {
+	// Configuration version - must be "1.0"
+	version: "1.0"
+
+	// Orchestrator server configuration
+	orchestrator: #OrchestratorConfig
+
+	// Sandbox runtime configuration
+	sandbox: #SandboxConfig
+
+	// Egress gateway configuration
+	egressGateway: #EgressGatewayConfig
+
+	// Credential vault configuration
+	credentials: #CredentialsConfig
+
+	// Communication channels configuration
+	channels: #ChannelsConfig
+
+	// Middleware configuration
+	middleware: #MiddlewareConfig
+
+	// Skills configuration
+	skills: #SkillsConfig
+
+	// Observability configuration
+	observability: #ObservabilityConfig
+
+	// Storage configuration
+	storage: #StorageConfig
+
+	// Alerting configuration
+	alerting: #AlertingConfig
+}
+
+// Orchestrator configuration
+// Defines the main orchestrator server settings
+#OrchestratorConfig: {
+	// Server host address (must be valid IPv4)
+	host: string & net.IPv4
+
+	// Server port (1024-65535, unprivileged ports)
+	port: int & >=1024 & <=65535
+
+	// Session management settings
+	session: {
+		// Maximum concurrent sessions (1-10)
+		maxConcurrent: int & >0 & <=10
+
+		// Idle session timeout in minutes
+		idleTimeoutMinutes: int & >=1
+
+		// Enable day boundary for session tracking
+		dayBoundaryEnabled: bool
+	}
+
+	// Context management settings
+	context: {
+		// Maximum tokens for context window
+		maxTokens: int & >=1000 & <=200000
+
+		// Token threshold for summarization trigger
+		summarizationThreshold: int
+
+		// Optional custom prompt for summarization
+		summarizationPrompt?: string
+	}
+}
+
+// Sandbox configuration
+// Defines the isolation environment settings
+#SandboxConfig: {
+	// Enable sandbox isolation
+	enabled: bool
+
+	// Sandbox timeout in seconds (minimum 60s)
+	timeoutSeconds: int & >=60
+
+	// Memory limit in megabytes (minimum 512MB)
+	memoryLimitMb: int & >=512
+
+	// CPU limit as percentage (10-100%)
+	cpuLimitPercent: int & >=10 & <=100
+
+	// Sandbox zone directories
+	zones: {
+		// Directory for skills
+		skills: string
+
+		// Directory for inputs
+		inputs: string
+
+		// Directory for work files
+		work: string
+
+		// Directory for outputs
+		outputs: string
+	}
+}
+
+// Egress gateway configuration
+// Defines the proxy and allowlist settings
+#EgressGatewayConfig: {
+	// HTTP proxy settings
+	http: {
+		// Enable HTTP proxy
+		enabled: bool
+
+		// HTTP proxy port (1024-65535)
+		port: int & >=1024 & <=65535
+	}
+
+	// SOCKS5 proxy settings
+	socks5: {
+		// Enable SOCKS5 proxy
+		enabled: bool
+
+		// SOCKS5 proxy port (1024-65535)
+		port: int & >=1024 & <=65535
+	}
+
+	// Domain allowlist settings
+	allowlist: {
+		// System-defined allowed domains
+		system: [...string]
+
+		// Owner-defined allowed domains
+		owner: [...string]
+
+		// TTL for allowlist entries in seconds (minimum 60s)
+		ttlSeconds: int & >=60
+	}
+}
+
+// Credentials configuration
+// Defines credential vault settings
+#CredentialsConfig: {
+	// Vault backend type
+	backend: string
+
+	// Keychain service name (for macOS Keychain)
+	keychainService?: string
+
+	// Secret service collection (for Linux)
+	secretServiceCollection?: string
+}
+
+// Channels configuration
+// Defines external communication channels
+#ChannelsConfig: {
+	// Telegram integration (optional)
+	telegram?: {
+		// Enable Telegram bot
+		enabled: bool
+
+		// Bot operation mode
+		mode: "webhook" | "polling"
+
+		// Webhook URL (required when mode is "webhook")
+		if mode == "webhook" {
+			webhookUrl!: string
+		}
+
+		// Secret token for webhook verification
+		secretToken?: string
+	}
+
+	// MCP server integration (optional)
+	mcp?: {
+		// Enable MCP servers
+		enabled: bool
+
+		// MCP server configurations
+		servers: [...#McpServerConfig]
+
+		// Connection timeout in seconds
+		connectionTimeoutSeconds: int
+	}
+}
+
+// MCP server configuration
+#McpServerConfig: {
+	// Server name
+	name: string
+
+	// Server command
+	command: string
+
+	// Server arguments
+	args?: [...string]
+
+	// Server environment variables
+	env?: {[string]: string}
+}
+
+// Middleware configuration
+// Defines enabled middleware components
+#MiddlewareConfig: {
+	// Enable human-in-the-loop middleware
+	humanInTheLoop: bool
+
+	// Enable memory middleware
+	memory: bool
+
+	// Enable skill loader middleware
+	skillLoader: bool
+}
+
+// Skills configuration
+// Defines skill management settings
+#SkillsConfig: {
+	// Auto-update skills
+	autoUpdate: bool
+
+	// Update check interval in hours
+	updateCheckIntervalHours: int
+
+	// Skill directory
+	directory: string
+
+	// Maximum skill execution time in seconds
+	executionTimeoutSeconds: int
+}
+
+// Observability configuration
+// Defines telemetry and logging settings
+#ObservabilityConfig: {
+	// Enable Langfuse tracing
+	langfuse: bool
+
+	// Langfuse public key
+	langfusePublicKey?: string
+
+	// Langfuse secret key
+	langfuseSecretKey?: string
+
+	// OpenTelemetry endpoint
+	otelEndpoint?: string
+
+	// Log level
+	logLevel: "DEBUG" | "INFO" | "WARN" | "ERROR"
+}
+
+// Storage configuration
+// Defines data persistence settings
+#StorageConfig: {
+	// Database settings
+	database: {
+		// Database path
+		path: string
+
+		// WAL mode enabled
+		walMode: bool
+
+		// Cache size in pages
+		cacheSize: int
+	}
+
+	// Backup settings
+	backup: {
+		// Enable automatic backups
+		enabled: bool
+
+		// Backup directory
+		directory: string
+
+		// Backup retention in days (1-365)
+		retentionDays: int & >=1 & <=365
+
+		// Backup interval in hours
+		intervalHours: int
+	}
+}
+
+// Alerting configuration
+// Defines notification and alerting settings
+#AlertingConfig: {
+	// Enable alerting
+	enabled: bool
+
+	// Evaluation interval in seconds (minimum 10s)
+	evaluationIntervalSeconds: int & >=10
+
+	// Suppression period in minutes after alert
+	suppressionMinutes: int & >=0
+
+	// Alert notification channels
+	channels: {
+		// Telegram channel configuration
+		telegram: #TelegramChannelConfig
+
+		// Email channel configuration (optional)
+		email?: #EmailChannelConfig
+	}
+}
+
+// Telegram alerting channel configuration
+#TelegramChannelConfig: {
+	// Enable Telegram alerts
+	enabled: bool
+
+	// Alert severity levels (must include all: CRITICAL, ERROR, WARN, INFO)
+	severity: ["CRITICAL", "ERROR", "WARN", "INFO"]
+
+	// Send immediate notifications
+	immediate: bool
+}
+
+// Email alerting channel configuration
+#EmailChannelConfig: {
+	// Enable email alerts
+	enabled: bool
+
+	// Alert severity levels (must include all: CRITICAL, ERROR, WARN, INFO)
+	severity: ["CRITICAL", "ERROR", "WARN", "INFO"]
+
+	// Enable digest emails
+	digest: bool
+
+	// Digest interval in minutes
+	digestIntervalMinutes: int
+}

--- a/nix/schema/example.config.yaml
+++ b/nix/schema/example.config.yaml
@@ -1,0 +1,112 @@
+# OpenKraken Configuration Example
+# This is a valid configuration that conforms to nix/schema/config.cue
+
+version: "1.0"
+
+orchestrator:
+  host: "127.0.0.1"
+  port: 3000
+  session:
+    maxConcurrent: 1
+    idleTimeoutMinutes: 30
+    dayBoundaryEnabled: true
+  context:
+    maxTokens: 100000
+    summarizationThreshold: 80000
+
+sandbox:
+  enabled: true
+  timeoutSeconds: 300
+  memoryLimitMb: 2048
+  cpuLimitPercent: 50
+  zones:
+    skills: "/var/lib/openkraken/skills"
+    inputs: "/var/lib/openkraken/inputs"
+    work: "/var/lib/openkraken/work"
+    outputs: "/var/lib/openkraken/outputs"
+
+egressGateway:
+  http:
+    enabled: true
+    port: 8080
+  socks5:
+    enabled: false
+    port: 1080
+  allowlist:
+    system:
+      - "api.openai.com"
+      - "api.anthropic.com"
+    owner:
+      - "example.com"
+      - "api.example.com"
+    ttlSeconds: 300
+
+credentials:
+  backend: "keychain"
+  keychainService: "OpenKraken"
+
+channels:
+  telegram:
+    enabled: false
+    mode: "webhook"
+    webhookUrl: "https://your-domain.com/webhook"
+    secretToken: "your-secret-token"
+  mcp:
+    enabled: false
+    servers:
+      - name: "filesystem"
+        command: "npx"
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    connectionTimeoutSeconds: 30
+
+middleware:
+  humanInTheLoop: false
+  memory: true
+  skillLoader: true
+
+skills:
+  autoUpdate: true
+  updateCheckIntervalHours: 24
+  directory: "/var/lib/openkraken/skills"
+  executionTimeoutSeconds: 300
+
+observability:
+  langfuse: false
+  langfusePublicKey: "pk-your-public-key"
+  langfuseSecretKey: "sk-your-secret-key"
+  otelEndpoint: "http://localhost:4318"
+  logLevel: "INFO"
+
+storage:
+  database:
+    path: "/var/lib/openkraken/db/openkraken.db"
+    walMode: true
+    cacheSize: 2000
+  backup:
+    enabled: true
+    directory: "/var/lib/openkraken/backups"
+    retentionDays: 30
+    intervalHours: 24
+
+alerting:
+  enabled: true
+  evaluationIntervalSeconds: 30
+  suppressionMinutes: 15
+  channels:
+    telegram:
+      enabled: true
+      severity:
+        - "CRITICAL"
+        - "ERROR"
+        - "WARN"
+        - "INFO"
+      immediate: true
+    email:
+      enabled: false
+      severity:
+        - "CRITICAL"
+        - "ERROR"
+        - "WARN"
+        - "INFO"
+      digest: true
+      digestIntervalMinutes: 60

--- a/packages/shared/devenv.nix
+++ b/packages/shared/devenv.nix
@@ -8,6 +8,7 @@
     parallel # Parallel execution
     fd # Fast file finder
     ripgrep # Fast line-oriented search
+    cue # CUE configuration validation
   ];
 
   # Pre-commit hooks


### PR DESCRIPTION
## Summary

Creates a CUE validation schema for `config.yaml` as specified in TechSpec Section 6.3. This provides build-time and runtime configuration validation for the OpenKraken project.

## Changes

- **`nix/schema/config.cue`**: Full CUE schema with validation rules for:
  - `#Config` - Main configuration container with version "1.0"
  - `#OrchestratorConfig` - Host (IPv4), port (1024-65535), session/context settings
  - `#SandboxConfig` - Enabled, timeout, memory, CPU limits, zones
  - `#EgressGatewayConfig` - HTTP/SOCKS5 ports, allowlist with TTL
  - `#ChannelsConfig` - Telegram and MCP server configurations
  - `#AlertingConfig` - Alerting channels and severity levels
  - Plus: CredentialsConfig, MiddlewareConfig, SkillsConfig, ObservabilityConfig, StorageConfig

- **`nix/schema/example.config.yaml`**: Valid example configuration for testing

- **`flake.nix`**: Added `checks.config-validation` for `nix flake check`

- **`packages/shared/devenv.nix`**: Added `cue` package for development

## Verification

- Valid config passes `cue vet -c -d '#Config' nix/schema/config.cue example.config.yaml` (exit 0)
- Invalid config fails with clear error messages showing field paths, type mismatches, and value conflicts
- `nix flake check` runs CUE validation successfully

## Testing the Schema

```bash
# Validate a config file
devenv shell -- cue vet -c -d '#Config' nix/schema/config.cue your-config.yaml

# Run flake checks
nix flake check
```

Closes: #13