### PR TITLE
infra: add GitHub Actions CI/CD pipeline (INFRA-013)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: OpenKraken CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            system: x86_64-linux
+          - os: macos-latest
+            system: aarch64-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-25.11
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Cache Nix store (eval + build cache)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/nix
+            ~/.config/nix
+          key: nix-${{ matrix.os }}-${{ hashFiles('**/flake.lock', '**/devenv.lock') }}
+          restore-keys: |
+            nix-${{ matrix.os }}-
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: openkraken
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: devenv, cachix
+
+      - name: Install devenv
+        run: nix profile install nixpkgs#devenv
+
+      - name: Build Orchestrator
+        run: nix build .#packages.${{ matrix.system }}.openkraken-orchestrator
+
+      - name: Build Gateway
+        run: nix build .#packages.${{ matrix.system }}.openkraken-gateway
+
+      - name: Run Devenv Tests
+        run: devenv test --no-cached
+
+      - name: Generate SBOM
+        run: nix run .#sbom
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.os }}
+          path: sbom-*.json
+          retention-days: 90
+
+      - name: Build and verify
+        run: |
+          devenv tasks run build
+
+      - name: Push to Cachix (main branch only)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          nix copy --to cachix://openkraken result


### PR DESCRIPTION
## Summary

- Implements GitHub Actions CI/CD pipeline with Nix-first approach per TechSpec Section 9.3
- Adds matrix builds for ubuntu-latest (x86_64-linux) and macos-latest (aarch64-darwin)
- Configures Cachix binary caching for reproducible builds
- Adds SBOM generation and artifact upload with 90-day retention

## Changes

| Step | Action |
|------|--------|
| Checkout | actions/checkout@v4 with fetch-depth: 0 |
| Install Nix | cachix/install-nix-action@v31 |
| Cache Nix Store | actions/cache@v4 |
| Setup Cachix | cachix/cachix-action@v16 |
| Build Orchestrator | nix build .#packages.${{ matrix.system }}.openkraken-orchestrator |
| Build Gateway | nix build .#packages.${{ matrix.system }}.openkraken-gateway |
| Run Devenv Tests | devenv test --no-cached |
| Generate SBOM | nix run .#sbom |
| Upload Artifacts | actions/upload-artifact@v4 |
| Push to Cachix | nix copy --to cachix://openkraken result (main only) |

## Requirements

- CACHIX_AUTH_TOKEN secret must be added to repository for Cachix to function
- Repository must have Cachix cache openkraken configured

## Testing

- Workflow can be triggered manually via workflow_dispatch
- Will run on PRs to main and pushes to main

Closes: #14