### PR TITLE
feat(credentials): implement credential vault with D-Bus and age-encrypted fallback (INFRA-015)

### DIFF
--- a/nix/nixos-modules/dbus-secrets.nix
+++ b/nix/nixos-modules/dbus-secrets.nix
@@ -1,0 +1,68 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.openkraken;
+in
+{
+  # INFRA-015: Credential Vault Access Configuration
+  # Configures D-Bus access for the openkraken service user to access
+  # the secret-service API (org.freedesktop.secrets) on Linux.
+  #
+  # Architecture Notes:
+  # - This configures the SYSTEM bus policy for secret-service access
+  # - secret-service (gnome-keyring) typically runs on the SESSION bus
+  # - On headless servers without an active login session, the session bus
+  #   doesn't exist, so Bun.secrets will fail and fall back to age-encrypted file
+  # - The system bus policy is kept for completeness and for configurations
+  #   where secret-service might be configured on the system bus
+  #
+  # This enables credential retrieval via:
+  # - Bun.secrets (which uses libsecret internally) - requires session bus
+  # - secret-tool CLI: sudo -u openkraken secret-tool lookup openkraken test
+  #
+  # For headless servers without secret-service, the CredentialVault
+  # falls back to age-encrypted credentials.enc file.
+  config = mkIf cfg.enable {
+    # D-Bus system bus policy for secret-service access
+    # Allows the openkraken user to communicate with the secret service daemon
+    services.dbus.packages = [
+      (pkgs.writeTextDir "etc/dbus-1/system.d/org.freedesktop.secrets.conf" ''
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!--
+          D-Bus policy for OpenKraken secret-service access (INFRA-015)
+          Grants the openkraken service user access to the freedesktop secret service API.
+          This enables credential retrieval via Bun.secrets and secret-tool.
+        -->
+        <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+         "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+        <busconfig>
+          <!-- Grant openkraken user access to secret-service -->
+          <policy user="openkraken">
+            <allow send_destination="org.freedesktop.secrets"
+                   send_interface="org.freedesktop.Secret.Service"/>
+            <allow send_destination="org.freedesktop.secrets"
+                   send_interface="org.freedesktop.Secret.Collection"/>
+            <allow send_destination="org.freedesktop.secrets"
+                   send_interface="org.freedesktop.Secret.Item"/>
+            <allow send_destination="org.freedesktop.secrets"
+                   send_interface="org.freedesktop.Secret.Prompt"/>
+            <allow receive_sender="org.freedesktop.secrets"/>
+          </policy>
+
+          <!-- Default deny for others -->
+          <policy at_console="false">
+            <deny send_destination="org.freedesktop.secrets"/>
+          </policy>
+        </busconfig>
+      '')
+    ];
+
+    # Ensure libsecret is available for Bun.secrets to use
+    # libsecret provides both the runtime library and secret-tool CLI
+    environment.systemPackages = mkIf (cfg.orchestrator.enable || cfg.gateway.enable) [
+      pkgs.libsecret
+    ];
+  };
+}

--- a/nix/nixos-modules/openkraken.nix
+++ b/nix/nixos-modules/openkraken.nix
@@ -7,6 +7,11 @@ let
 in
 
 {
+  # INFRA-015: Import D-Bus secret-service configuration for credential vault access
+  imports = [
+    ./dbus-secrets.nix
+  ];
+
   options.services.openkraken = {
     enable = mkOption {
       type = types.bool;
@@ -118,6 +123,11 @@ in
           "OPENKRAKEN_HOME=${cfg.orchestrator.dataDir}"
           "OPENKRAKEN_CONFIG=${cfg.orchestrator.configDir}/config.yaml"
           "ORCHESTRATOR_PORT=${toString cfg.orchestrator.port}"
+          # INFRA-015: D-Bus session bus for credential vault access
+          # Note: On headless servers without a login session, this path won't exist,
+          # causing Bun.secrets to fail and fall back to age-encrypted file (expected).
+          # On desktop systems with gnome-keyring, this enables native vault access.
+          "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus"
         ];
         ExecStart = "${cfg.orchestrator.package}/bin/openkraken";
         PrivateTmp = true;

--- a/packages/orchestrator/bun.lock
+++ b/packages/orchestrator/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@openkraken/orchestrator",
+      "dependencies": {
+        "age-encryption": "^0.3.0",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.3.13",
         "@types/bun": "latest",
@@ -41,9 +44,21 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
 
+    "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
+
+    "@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
+
+    "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "@noble/post-quantum": ["@noble/post-quantum@0.5.4", "", { "dependencies": { "@noble/curves": "~2.0.0", "@noble/hashes": "~2.0.0" } }, "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w=="],
+
+    "@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
+
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
+
+    "age-encryption": ["age-encryption@0.3.0", "", { "dependencies": { "@noble/ciphers": "^2.1.1", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/post-quantum": "^0.5.3", "@scure/base": "^2.0.0" } }, "sha512-vDhGGp5ZXpbKL6oc3FEBjGhyepr/0SwIWmia6CcPXvYcxGBSQNcDdMv9m2yVOkjjYuJEmtGEhOojIUcjrj0cEw=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -8,6 +8,9 @@
     "check": "bunx biome check --write",
     "fix": "bunx biome check --write"
   },
+  "dependencies": {
+    "age-encryption": "^0.3.0"
+  },
   "peerDependencies": {
     "typescript": "^5"
   },

--- a/packages/orchestrator/src/credentials/__tests__/vault.test.ts
+++ b/packages/orchestrator/src/credentials/__tests__/vault.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for Credential Vault (INFRA-015)
+ *
+ * Note: These tests focus on logic that can be tested without requiring
+ * actual system vault access. Tests for secrets API integration require
+ * a running secret-service (on Linux) or Keychain access (on macOS).
+ *
+ * To run integration tests with real vault access:
+ * - Linux: Ensure gnome-keyring or kwallet is running
+ * - macOS: Keychain access is available by default
+ */
+
+import { describe, expect, test } from "bun:test";
+import { CredentialError } from "../types";
+import { CredentialVault } from "../vault";
+
+describe("CredentialError", () => {
+  test("creates error with correct properties", () => {
+    const error = new CredentialError("not_found", "Credential not found");
+
+    expect(error.name).toBe("CredentialError");
+    expect(error.type).toBe("not_found");
+    expect(error.message).toBe("Credential not found");
+  });
+
+  test("includes cause when provided", () => {
+    const cause = new Error("Original error");
+    const error = new CredentialError(
+      "provider_unavailable",
+      "Provider failed",
+      cause
+    );
+
+    expect(error.cause).toBe(cause);
+  });
+
+  test("supports all error types", () => {
+    const errorTypes = [
+      "not_found",
+      "provider_unavailable",
+      "encryption_error",
+      "permission_denied",
+      "invalid_format",
+    ] as const;
+
+    for (const type of errorTypes) {
+      const error = new CredentialError(type, `Test ${type}`);
+      expect(error.type).toBe(type);
+    }
+  });
+});
+
+describe("CredentialVault", () => {
+  test("getActiveBackend returns null before initialization", () => {
+    const originalHome = process.env.OPENKRAKEN_HOME;
+    try {
+      process.env.OPENKRAKEN_HOME = "/tmp/test";
+      const vault = new CredentialVault({ serviceName: "test" });
+      expect(vault.getActiveBackend()).toBeNull();
+    } finally {
+      process.env.OPENKRAKEN_HOME = originalHome;
+    }
+  });
+
+  test("isUsingFallback returns false before initialization", () => {
+    const originalHome = process.env.OPENKRAKEN_HOME;
+    try {
+      process.env.OPENKRAKEN_HOME = "/tmp/test";
+      const vault = new CredentialVault({ serviceName: "test" });
+      expect(vault.isUsingFallback()).toBe(false);
+    } finally {
+      process.env.OPENKRAKEN_HOME = originalHome;
+    }
+  });
+
+  test("throws when OPENKRAKEN_HOME is not set", () => {
+    const originalHome = process.env.OPENKRAKEN_HOME;
+    try {
+      process.env.OPENKRAKEN_HOME = undefined;
+      expect(() => new CredentialVault()).toThrow(
+        "OPENKRAKEN_HOME environment variable is not set"
+      );
+    } finally {
+      process.env.OPENKRAKEN_HOME = originalHome;
+    }
+  });
+
+  test("accepts custom service name", () => {
+    const originalHome = process.env.OPENKRAKEN_HOME;
+    try {
+      process.env.OPENKRAKEN_HOME = "/tmp/test";
+      const vault = new CredentialVault({ serviceName: "custom-service" });
+      expect(vault).toBeDefined();
+    } finally {
+      process.env.OPENKRAKEN_HOME = originalHome;
+    }
+  });
+
+  test("accepts custom encrypted file path", () => {
+    const originalHome = process.env.OPENKRAKEN_HOME;
+    try {
+      process.env.OPENKRAKEN_HOME = "/tmp/test";
+      const vault = new CredentialVault({
+        serviceName: "test",
+        encryptedFilePath: "/custom/path/credentials.enc",
+      });
+      expect(vault).toBeDefined();
+    } finally {
+      process.env.OPENKRAKEN_HOME = originalHome;
+    }
+  });
+});
+
+describe("Types", () => {
+  test("VaultBackend type allows expected values", () => {
+    const bunSecrets = "bun-secrets";
+    const ageEncrypted = "age-encrypted";
+
+    expect(bunSecrets).toBe("bun-secrets");
+    expect(ageEncrypted).toBe("age-encrypted");
+  });
+
+  test("CredentialResult interface is correct shape", () => {
+    const result = {
+      value: "test-value",
+      backend: "bun-secrets" as const,
+      fallback: false,
+    };
+
+    expect(result.value).toBe("test-value");
+    expect(result.backend).toBe("bun-secrets");
+    expect(result.fallback).toBe(false);
+  });
+
+  test("CredentialResult with null value is valid", () => {
+    const result = {
+      value: null,
+      backend: "age-encrypted" as const,
+      fallback: true,
+    };
+
+    expect(result.value).toBeNull();
+    expect(result.fallback).toBe(true);
+  });
+});

--- a/packages/orchestrator/src/credentials/providers/age-encrypted.ts
+++ b/packages/orchestrator/src/credentials/providers/age-encrypted.ts
@@ -1,0 +1,381 @@
+/**
+ * Age-Encrypted Credential Provider (INFRA-015)
+ *
+ * Provides credential storage using age-encrypted files for headless servers
+ * where secret-service is unavailable. This is the fallback when Bun.secrets
+ * cannot connect to a secret service daemon.
+ *
+ * Architecture:
+ * - Master key (age identity) is stored in Bun.secrets, env variable, or file
+ * - Credentials are stored in an age-encrypted JSON file
+ * - File must have permissions 0600 (owner read/write only)
+ *
+ * The encrypted file path defaults to $OPENKRAKEN_HOME/credentials.enc
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  Decrypter,
+  Encrypter,
+  generateIdentity,
+  identityToRecipient,
+} from "age-encryption";
+import { secrets } from "bun";
+import type { CredentialProvider, VaultBackend } from "../types";
+
+/**
+ * Key name for storing the age identity in secrets API
+ */
+const MASTER_KEY_NAME = "__openkraken_age_identity__";
+
+/**
+ * Filename for file-based age identity (fallback when secrets API unavailable)
+ */
+const IDENTITY_FILENAME = ".age_identity";
+
+/**
+ * Expected file permissions for encrypted files and identity file
+ */
+const EXPECTED_FILE_MODE = 0o600;
+
+/**
+ * Age-encrypted credential provider implementation
+ */
+export class AgeEncryptedProvider implements CredentialProvider {
+  readonly name: VaultBackend = "age-encrypted";
+
+  private readonly encryptedFilePath: string;
+  private readonly identityFilePath: string;
+  private readonly serviceName: string;
+  private cachedIdentity: string | null = null;
+  private cachedCredentials: Record<string, string> | null = null;
+
+  constructor(serviceName: string, encryptedFilePath: string) {
+    this.serviceName = serviceName;
+    this.encryptedFilePath = encryptedFilePath;
+    // Identity file lives alongside the encrypted credentials file
+    this.identityFilePath = join(dirname(encryptedFilePath), IDENTITY_FILENAME);
+  }
+
+  /**
+   * Check if this provider is available
+   *
+   * Returns true if:
+   * 1. The encrypted credentials file exists with correct permissions, OR
+   * 2. We can create a new encrypted file
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      // Check if file exists
+      if (!existsSync(this.encryptedFilePath)) {
+        // Can potentially create - available if we have a master key
+        return await this.hasMasterKey();
+      }
+
+      // Verify file permissions
+      const stats = statSync(this.encryptedFilePath);
+      // Extract permission bits (lower 9 bits of mode)
+      const mode = stats.mode % 0o1000;
+      if (mode !== EXPECTED_FILE_MODE) {
+        console.warn(
+          `credentials.enc has incorrect permissions ${mode.toString(8).padStart(3, "0")}, expected 600. ` +
+            "Run: chmod 600 <credentials.enc>"
+        );
+        return false;
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check if we have access to the master key
+   */
+  private async hasMasterKey(): Promise<boolean> {
+    // First check environment variable
+    if (process.env.OPENKRAKEN_AGE_IDENTITY) {
+      return true;
+    }
+
+    // Then check file-based identity (fallback for headless servers)
+    if (existsSync(this.identityFilePath)) {
+      return true;
+    }
+
+    // Finally check secrets API
+    try {
+      const identity = await secrets.get({
+        service: this.serviceName,
+        name: MASTER_KEY_NAME,
+      });
+      return identity !== null;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get the age identity (private key) for decryption
+   */
+  private async getIdentity(): Promise<string> {
+    if (this.cachedIdentity) {
+      return this.cachedIdentity;
+    }
+
+    // First check environment variable (for development/testing)
+    const envIdentity = process.env.OPENKRAKEN_AGE_IDENTITY;
+    if (envIdentity) {
+      this.cachedIdentity = envIdentity;
+      return envIdentity;
+    }
+
+    // Then check file-based identity (fallback for headless servers)
+    if (existsSync(this.identityFilePath)) {
+      try {
+        const identity = readFileSync(this.identityFilePath, "utf-8").trim();
+        if (identity) {
+          this.cachedIdentity = identity;
+          return identity;
+        }
+      } catch {
+        // Fall through to secrets API check
+      }
+    }
+
+    // Finally check secrets API
+    try {
+      const identity = await secrets.get({
+        service: this.serviceName,
+        name: MASTER_KEY_NAME,
+      });
+
+      if (!identity) {
+        throw new Error(
+          "Age identity not found. Set OPENKRAKEN_AGE_IDENTITY environment variable, " +
+            "provision a .age_identity file, or run: openkraken credentials init"
+        );
+      }
+
+      this.cachedIdentity = identity;
+      return identity;
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Age identity not found")
+      ) {
+        throw error;
+      }
+      throw new Error(
+        `Failed to retrieve age identity: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Get the public key (recipient) from the identity
+   */
+  private async getRecipient(): Promise<string> {
+    const identity = await this.getIdentity();
+    return await identityToRecipient(identity);
+  }
+
+  /**
+   * Load and decrypt credentials from the encrypted file
+   */
+  private async loadCredentials(): Promise<Record<string, string>> {
+    if (this.cachedCredentials) {
+      return this.cachedCredentials;
+    }
+
+    if (!existsSync(this.encryptedFilePath)) {
+      // No file yet - return empty credentials
+      this.cachedCredentials = {};
+      return {};
+    }
+
+    try {
+      const encryptedContent = readFileSync(this.encryptedFilePath, "utf-8");
+      const identity = await this.getIdentity();
+
+      const decrypter = new Decrypter();
+      decrypter.addIdentity(identity);
+
+      const decrypted = await decrypter.decrypt(encryptedContent, "text");
+      const credentials = JSON.parse(decrypted as string) as Record<
+        string,
+        string
+      >;
+
+      this.cachedCredentials = credentials;
+      return credentials;
+    } catch (error) {
+      throw new Error(
+        `Failed to decrypt credentials: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Encrypt and save credentials to the file
+   */
+  private async saveCredentials(
+    credentials: Record<string, string>
+  ): Promise<void> {
+    try {
+      const recipient = await this.getRecipient();
+      const cipher = new Encrypter();
+      cipher.addRecipient(recipient);
+
+      const plaintext = JSON.stringify(credentials, null, 2);
+      const encrypted = (await cipher.encrypt(plaintext)) as string;
+
+      // Write file
+      writeFileSync(this.encryptedFilePath, encrypted, {
+        mode: EXPECTED_FILE_MODE,
+      });
+
+      // Ensure correct permissions (writeFileSync mode may not work on all platforms)
+      chmodSync(this.encryptedFilePath, EXPECTED_FILE_MODE);
+      this.cachedCredentials = credentials;
+    } catch (error) {
+      throw new Error(
+        `Failed to encrypt credentials: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Retrieve a credential
+   */
+  async get(key: string): Promise<string | null> {
+    const credentials = await this.loadCredentials();
+    return credentials[key] ?? null;
+  }
+
+  /**
+   * Store a credential
+   */
+  async set(key: string, value: string): Promise<void> {
+    const credentials = await this.loadCredentials();
+    credentials[key] = value;
+    await this.saveCredentials(credentials);
+  }
+
+  /**
+   * Delete a credential
+   */
+  async delete(key: string): Promise<boolean> {
+    const credentials = await this.loadCredentials();
+
+    if (!(key in credentials)) {
+      return false;
+    }
+
+    delete credentials[key];
+    await this.saveCredentials(credentials);
+    return true;
+  }
+
+  /**
+   * List all credential keys
+   */
+  async list(): Promise<string[]> {
+    const credentials = await this.loadCredentials();
+    return Object.keys(credentials);
+  }
+
+  /**
+   * Initialize a new age identity and store it
+   *
+   * This should be called once during initial setup to generate
+   * the master encryption key.
+   *
+   * Storage priority:
+   * 1. Secrets API (if available) - preferred for desktop systems
+   * 2. File-based (.age_identity) - fallback for headless servers
+   */
+  async initializeIdentity(): Promise<{ identity: string; recipient: string }> {
+    const identity = await generateIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    // Try to store in secrets API first
+    let storedInVault = false;
+    try {
+      await secrets.set({
+        service: this.serviceName,
+        name: MASTER_KEY_NAME,
+        value: identity,
+      });
+      storedInVault = true;
+    } catch {
+      // Secrets API unavailable - falling back to file-based storage
+      console.info(
+        "[AgeEncryptedProvider] Secrets API unavailable, using file-based identity storage"
+      );
+    }
+
+    // If secrets API failed, store in file
+    if (!storedInVault) {
+      try {
+        // Ensure parent directory exists
+        const parentDir = dirname(this.identityFilePath);
+        if (!existsSync(parentDir)) {
+          throw new Error(`Parent directory does not exist: ${parentDir}`);
+        }
+
+        // Write identity file with restricted permissions
+        writeFileSync(this.identityFilePath, identity, {
+          mode: EXPECTED_FILE_MODE,
+        });
+        chmodSync(this.identityFilePath, EXPECTED_FILE_MODE);
+      } catch (error) {
+        throw new Error(
+          `Failed to store age identity: ${error instanceof Error ? error.message : String(error)}. ` +
+            "Ensure OPENKRAKEN_HOME exists and is writable."
+        );
+      }
+    }
+
+    this.cachedIdentity = identity;
+    return { identity, recipient };
+  }
+
+  /**
+   * Clear the in-memory cache
+   */
+  clearCache(): void {
+    this.cachedIdentity = null;
+    this.cachedCredentials = null;
+  }
+}
+
+/**
+ * Default path for the encrypted credentials file
+ */
+export function getDefaultCredentialsPath(): string {
+  const home = process.env.OPENKRAKEN_HOME;
+  if (!home) {
+    throw new Error("OPENKRAKEN_HOME environment variable is not set");
+  }
+  return join(home, "credentials.enc");
+}
+
+/**
+ * Factory function to create an age-encrypted provider
+ */
+export function createAgeEncryptedProvider(
+  serviceName: string,
+  encryptedFilePath?: string
+): CredentialProvider {
+  const path = encryptedFilePath ?? getDefaultCredentialsPath();
+  return new AgeEncryptedProvider(serviceName, path);
+}

--- a/packages/orchestrator/src/credentials/providers/bun-secrets.ts
+++ b/packages/orchestrator/src/credentials/providers/bun-secrets.ts
@@ -1,0 +1,121 @@
+/**
+ * Bun.secrets Credential Provider (INFRA-015)
+ *
+ * Provides credential storage using Bun's native secrets API.
+ * This uses platform-specific secure storage:
+ * - macOS: Keychain Services
+ * - Linux: libsecret (GNOME Keyring, KWallet)
+ * - Windows: Credential Manager
+ *
+ * On headless Linux servers without a secret service daemon,
+ * this provider will be unavailable and the age-encrypted fallback
+ * should be used instead.
+ */
+
+import { secrets } from "bun";
+import type { CredentialProvider, VaultBackend } from "../types";
+/**
+ * Bun.secrets credential provider implementation
+ */
+export class BunSecretsProvider implements CredentialProvider {
+  readonly name: VaultBackend = "bun-secrets";
+
+  /**
+   * Service name used to namespace credentials in the vault
+   */
+  private readonly serviceName: string;
+
+  constructor(serviceName: string) {
+    this.serviceName = serviceName;
+  }
+
+  /**
+   * Check if Bun.secrets is available on this system
+   *
+   * This tests actual vault availability by attempting to read a test key.
+   * On headless Linux servers without secret-service, this will return false.
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      // secrets API may throw if the underlying vault is unavailable
+      // Test by attempting a read operation
+      const testKey = "__openkraken_vault_test__";
+      await secrets.get({ service: this.serviceName, name: testKey });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Retrieve a credential from the vault
+   */
+  async get(key: string): Promise<string | null> {
+    try {
+      const value = await secrets.get({
+        service: this.serviceName,
+        name: key,
+      });
+      return value;
+    } catch {
+      // Return null if the credential doesn't exist or vault is unavailable
+      return null;
+    }
+  }
+
+  /**
+   * Store a credential in the vault
+   */
+  async set(key: string, value: string): Promise<void> {
+    await secrets.set({
+      service: this.serviceName,
+      name: key,
+      value,
+    });
+  }
+
+  /**
+   * Delete a credential from the vault
+   *
+   * @returns true if the credential was deleted, false if it didn't exist
+   */
+  async delete(key: string): Promise<boolean> {
+    try {
+      // Check if credential exists first
+      const existing = await this.get(key);
+      if (existing === null) {
+        return false;
+      }
+
+      await secrets.delete({
+        service: this.serviceName,
+        name: key,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * List all credential keys for this service
+   *
+   * Note: secrets doesn't provide a list operation, so this returns
+   * an empty array. The vault abstraction layer should track keys separately
+   * if listing is needed.
+   */
+  list(): string[] {
+    // secrets API doesn't support listing
+    // Return empty array - vault layer should track keys if needed
+    return [];
+  }
+}
+
+/**
+ * Factory function to create a Bun.secrets provider
+ */
+export function createBunSecretsProvider(
+  serviceName: string
+): CredentialProvider {
+  return new BunSecretsProvider(serviceName);
+}

--- a/packages/orchestrator/src/credentials/types.ts
+++ b/packages/orchestrator/src/credentials/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Credential Vault Types (INFRA-015)
+ *
+ * Type definitions for the credential vault abstraction.
+ * Supports platform-native vaults (Bun.secrets) with age-encrypted file fallback.
+ */
+
+/**
+ * Supported vault backend types
+ */
+export type VaultBackend = "bun-secrets" | "age-encrypted";
+
+/**
+ * Configuration for the credential vault
+ */
+export interface CredentialVaultConfig {
+  /** Service name used to identify credentials in the vault */
+  serviceName: string;
+  /** Path to age-encrypted credentials file for fallback */
+  encryptedFilePath?: string;
+  /** Enable development mode with environment variable fallback */
+  developmentMode?: boolean;
+}
+
+/**
+ * Provider interface for credential storage backends
+ */
+export interface CredentialProvider {
+  /** Unique identifier for this provider */
+  readonly name: VaultBackend;
+
+  /** Check if this provider is available on the current system */
+  isAvailable(): Promise<boolean>;
+
+  /** Retrieve a credential by key */
+  get(key: string): Promise<string | null>;
+
+  /** Store a credential */
+  set(key: string, value: string): Promise<void>;
+
+  /** Delete a credential */
+  delete(key: string): Promise<boolean>;
+
+  /** List all credential keys */
+  list?(): string[] | Promise<string[]>;
+
+  /**
+   * Initialize a new identity for this provider (optional)
+   *
+   * Used by providers that require initialization before use,
+   * such as age-encrypted file storage on headless servers.
+   */
+  initializeIdentity?(): Promise<{ identity: string; recipient: string }>;
+}
+
+/**
+ * Result of credential retrieval operation
+ */
+export interface CredentialResult {
+  /** The retrieved credential value, or null if not found */
+  value: string | null;
+  /** The backend that provided the credential */
+  backend: VaultBackend;
+  /** Whether a fallback was used */
+  fallback: boolean;
+}
+
+/**
+ * Error types for credential operations
+ */
+export type CredentialErrorType =
+  | "not_found"
+  | "provider_unavailable"
+  | "encryption_error"
+  | "permission_denied"
+  | "invalid_format";
+
+/**
+ * Error thrown by credential vault operations
+ */
+export class CredentialError extends Error {
+  readonly type: CredentialErrorType;
+  readonly cause?: Error;
+
+  constructor(type: CredentialErrorType, message: string, cause?: Error) {
+    super(message);
+    this.name = "CredentialError";
+    this.type = type;
+    this.cause = cause;
+  }
+}

--- a/packages/orchestrator/src/credentials/vault.ts
+++ b/packages/orchestrator/src/credentials/vault.ts
@@ -1,0 +1,314 @@
+/**
+ * Credential Vault (INFRA-015)
+ *
+ * Unified credential vault abstraction with automatic fallback chain.
+ *
+ * Fallback Flow (per Architecture.md §5.1):
+ * Primary: secrets API (secret-service/D-Bus on Linux, Keychain on macOS)
+ *     ↓ (unavailable - headless server without secret-service)
+ * Fallback: age-encrypted file ($OPENKRAKEN_HOME/credentials.enc)
+ *     ↓ (missing)
+ * Error: Credential provisioning required
+ *
+ * Security:
+ * - Credentials are never logged or written to filesystem in plaintext
+ * - Age-encrypted fallback file must have permissions 0600
+ * - Master key for age encryption stored in OS vault
+ */
+
+import {
+  createAgeEncryptedProvider,
+  getDefaultCredentialsPath,
+} from "./providers/age-encrypted";
+import { createBunSecretsProvider } from "./providers/bun-secrets";
+import type {
+  CredentialProvider,
+  CredentialVaultConfig,
+  VaultBackend,
+} from "./types";
+import { CredentialError } from "./types";
+
+/**
+ * Default service name for OpenKraken credentials
+ */
+const DEFAULT_SERVICE_NAME = "openkraken";
+
+/**
+ * Credential Vault - unified abstraction for credential storage
+ *
+ * Implements the fallback chain for credential retrieval:
+ * 1. Try secrets API (platform-native vault)
+ * 2. Fall back to age-encrypted file if unavailable
+ * 3. Throw error if neither is available
+ */
+export class CredentialVault {
+  private readonly config: CredentialVaultConfig;
+  private readonly bunSecretsProvider: CredentialProvider;
+  private readonly ageEncryptedProvider: CredentialProvider;
+  private activeProvider: CredentialProvider | null = null;
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
+
+  constructor(config?: Partial<CredentialVaultConfig>) {
+    this.config = {
+      serviceName: config?.serviceName ?? DEFAULT_SERVICE_NAME,
+      encryptedFilePath:
+        config?.encryptedFilePath ?? getDefaultCredentialsPath(),
+      developmentMode: config?.developmentMode ?? false,
+    };
+
+    this.bunSecretsProvider = createBunSecretsProvider(this.config.serviceName);
+    this.ageEncryptedProvider = createAgeEncryptedProvider(
+      this.config.serviceName,
+      this.config.encryptedFilePath
+    );
+  }
+
+  /**
+   * Initialize the vault and determine the active provider
+   *
+   * This must be called before any credential operations.
+   * Uses a promise-based lock to handle concurrent initialization safely.
+   */
+  async initialize(): Promise<void> {
+    // Return immediately if already initialized
+    if (this.initialized) {
+      return;
+    }
+
+    // If initialization is in progress, wait for it to complete
+    if (this.initPromise) {
+      await this.initPromise;
+      return;
+    }
+
+    // Start initialization and store the promise
+    this.initPromise = this.doInitialize();
+    await this.initPromise;
+  }
+
+  /**
+   * Internal initialization logic
+   */
+  private async doInitialize(): Promise<void> {
+    // Try primary provider first
+    const bunSecretsAvailable = await this.bunSecretsProvider.isAvailable();
+
+    if (bunSecretsAvailable) {
+      this.activeProvider = this.bunSecretsProvider;
+      console.info("[CredentialVault] Using primary provider: bun-secrets");
+    } else {
+      // Fall back to age-encrypted provider
+      const ageEncryptedAvailable =
+        await this.ageEncryptedProvider.isAvailable();
+
+      if (ageEncryptedAvailable) {
+        this.activeProvider = this.ageEncryptedProvider;
+        console.warn(
+          "[CredentialVault] secret-service unavailable, using encrypted file fallback"
+        );
+      } else {
+        // Neither provider available - credential provisioning required
+        throw new CredentialError(
+          "provider_unavailable",
+          "No credential vault available. " +
+            "Ensure secret-service is running or provision credentials.enc file. " +
+            "On headless Linux, run: openkraken credentials init"
+        );
+      }
+    }
+
+    this.initialized = true;
+  }
+
+  /**
+   * Ensure vault is initialized before operations
+   * Returns the active provider for use in operations
+   */
+  private async ensureInitialized(): Promise<CredentialProvider> {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+
+    if (!this.activeProvider) {
+      throw new CredentialError(
+        "provider_unavailable",
+        "Credential vault not initialized"
+      );
+    }
+
+    return this.activeProvider;
+  }
+
+  /**
+   * Get the currently active provider backend
+   */
+  getActiveBackend(): VaultBackend | null {
+    return this.activeProvider?.name ?? null;
+  }
+
+  /**
+   * Check if we're using the fallback provider
+   */
+  isUsingFallback(): boolean {
+    return this.activeProvider?.name === "age-encrypted";
+  }
+
+  /**
+   * Retrieve a credential
+   *
+   * @param key - The credential key (e.g., "anthropic-api-key")
+   * @returns The credential value or null if not found
+   */
+  async get(key: string): Promise<{
+    value: string | null;
+    backend: VaultBackend;
+    fallback: boolean;
+  }> {
+    const provider = await this.ensureInitialized();
+
+    const value = await provider.get(key);
+    const fallback = this.isUsingFallback();
+
+    if (value === null) {
+      return { value: null, backend: provider.name, fallback };
+    }
+
+    return { value, backend: provider.name, fallback };
+  }
+
+  /**
+   * Store a credential
+   *
+   * @param key - The credential key
+   * @param value - The credential value
+   */
+  async set(key: string, value: string): Promise<void> {
+    const provider = await this.ensureInitialized();
+    await provider.set(key, value);
+  }
+
+  /**
+   * Delete a credential
+   *
+   * @param key - The credential key
+   * @returns true if deleted, false if not found
+   */
+  async delete(key: string): Promise<boolean> {
+    const provider = await this.ensureInitialized();
+    return provider.delete(key);
+  }
+
+  /**
+   * List all credential keys
+   *
+   * Note: For bun-secrets provider, this returns an empty array as
+   * secrets API doesn't support listing.
+   */
+  async list(): Promise<string[]> {
+    const provider = await this.ensureInitialized();
+
+    if (provider.list) {
+      const result = provider.list();
+      return result instanceof Promise ? await result : result;
+    }
+
+    return [];
+  }
+
+  /**
+   * Initialize the age-encrypted fallback for headless servers
+   *
+   * This generates a new age identity and stores it, then creates
+   * an empty credentials.enc file.
+   *
+   * Should only be called on headless servers where secret-service
+   * is unavailable.
+   */
+  async initializeFallback(): Promise<{ recipient: string }> {
+    const provider = this.ageEncryptedProvider;
+
+    if (!provider.initializeIdentity) {
+      throw new CredentialError(
+        "provider_unavailable",
+        "Age-encrypted provider does not support initialization"
+      );
+    }
+
+    const { recipient } = await provider.initializeIdentity();
+
+    // Create empty credentials file
+    await provider.set("__initialized__", new Date().toISOString());
+
+    return { recipient };
+  }
+
+  /**
+   * Force refresh of provider availability check
+   *
+   * Useful after environment changes (e.g., secret-service becomes available)
+   */
+  async refresh(): Promise<void> {
+    this.initialized = false;
+    this.initPromise = null;
+    this.activeProvider = null;
+    await this.initialize();
+  }
+}
+
+/**
+ * Singleton instance for convenience
+ */
+let vaultInstance: CredentialVault | null = null;
+
+/**
+ * Get the global credential vault instance
+ *
+ * Note: If an instance already exists, the config parameter is ignored.
+ * Use resetCredentialVault() first to create a new instance with different config.
+ */
+export function getCredentialVault(
+  config?: Partial<CredentialVaultConfig>
+): CredentialVault {
+  if (!vaultInstance) {
+    vaultInstance = new CredentialVault(config);
+  } else if (config) {
+    console.warn(
+      "[getCredentialVault] Config ignored - vault instance already exists. " +
+        "Call resetCredentialVault() first to reconfigure."
+    );
+  }
+  return vaultInstance;
+}
+
+/**
+ * Reset the global vault instance (for testing)
+ */
+export function resetCredentialVault(): void {
+  vaultInstance = null;
+}
+
+/**
+ * Convenience function to retrieve a credential
+ */
+export async function getCredential(key: string): Promise<string | null> {
+  const vault = getCredentialVault();
+  const result = await vault.get(key);
+  return result.value;
+}
+
+/**
+ * Convenience function to store a credential
+ */
+export async function setCredential(key: string, value: string): Promise<void> {
+  const vault = getCredentialVault();
+  await vault.set(key, value);
+}
+
+/**
+ * Convenience function to delete a credential
+ */
+export async function deleteCredential(key: string): Promise<boolean> {
+  const vault = getCredentialVault();
+  return await vault.delete(key);
+}

--- a/packages/orchestrator/src/platform/paths/constants.ts
+++ b/packages/orchestrator/src/platform/paths/constants.ts
@@ -115,12 +115,14 @@ export const MACOS_COCOA_PATHS: OpenKrakenDirectoryStructure = {
   config: {
     path: `~/Library/Application Support/${APP_NAME_MACOS}`,
     mode: PERMISSIONS.private,
-    description: "Configuration directory (macOS Application Support) - secured with 700",
+    description:
+      "Configuration directory (macOS Application Support) - secured with 700",
   },
   data: {
     path: `~/Library/Application Support/${APP_NAME_MACOS}`,
     mode: PERMISSIONS.private,
-    description: "Data directory (macOS Application Support) - secured with 700",
+    description:
+      "Data directory (macOS Application Support) - secured with 700",
   },
   logs: {
     path: `~/Library/Logs/${APP_NAME_MACOS}`,

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,11 @@
+# Typos configuration
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default]
+extend-ignore-re = [
+    # Ignore library class names that are intentionally spelled this way
+    "Encrypter",
+]
+
+[default.extend-identifiers]
+Encrypter = "Encrypter"


### PR DESCRIPTION
## Summary

Implements credential vault access configuration (INFRA-015) with automatic fallback from platform-native vaults to age-encrypted file storage for headless servers.

### Changes

**Nix Infrastructure**
- Add `dbus-secrets.nix` module configuring D-Bus system bus policy for secret-service access
- Configure `DBUS_SESSION_BUS_ADDRESS` environment variable for systemd services
- Include `libsecret` for runtime vault access

**TypeScript Implementation**
- `CredentialProvider` interface with `initializeIdentity?()` optional method
- `BunSecretsProvider`: Primary provider using `Bun.secrets` API (Keychain/secret-service)
- `AgeEncryptedProvider`: Fallback with file-based identity storage (`.age_identity`)
- `CredentialVault`: Unified abstraction with thread-safe initialization (promise-based lock)

**Fallback Chain**
```
Primary: Bun.secrets (secret-service/D-Bus on Linux, Keychain on macOS)
    ↓ (unavailable - headless server)
Fallback: age-encrypted file ($OPENKRAKEN_HOME/credentials.enc)
    ↓ (missing)
Error: Credential provisioning required
```

### Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| D-Bus access configured for openkraken user | ✅ |
| `/etc/dbus-1/system.d/org.freedesktop.secrets.conf` allows access | ✅ |
| Headless fallback to age-encrypted file | ✅ |
| `credentials.enc` permissions 600 enforced | ✅ |
| WARNING logged when using fallback | ✅ |
| macOS Keychain access via Bun.secrets | ✅ |

### Test Results

- 125 tests passed
- Biome check: No issues
- Nix syntax: Valid

Closes: #16
