### PR TITLE
feat(infra-018): add resource limits to systemd and launchd services

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -797,9 +797,9 @@ Then launchd plist includes:
   | Key                 | Value                                   |
   |---------------------|----------------------------------------|
   | HardResourceLimits  | NumberOfFiles: 8192                   |
-  |                     | MemorySize: 2147483648                 |
+  |                     | ResidentSetSize: 2147483648          |
   | SoftResourceLimits  | NumberOfFiles: 8192                   |
-  |                     | MemorySize: 2147483648                 |
+  |                     | ResidentSetSize: 2147483648          |
 ```
 
 ---

--- a/nix/darwin-modules/openkraken.nix
+++ b/nix/darwin-modules/openkraken.nix
@@ -95,6 +95,18 @@ in
           OPENKRAKEN_CONFIG = "${cfg.orchestrator.configDir}/config.yaml";
           ORCHESTRATOR_PORT = toString cfg.orchestrator.port;
         };
+
+        # INFRA-018: Resource Limits
+        # Per Tasks.md: Ensure stable operation under load
+        # Note: macOS launchd does not support CPU quotas (Linux cgroups feature)
+        SoftResourceLimits = {
+          NumberOfFiles = 8192;
+          ResidentSetSize = 2147483648; # 2GB
+        };
+        HardResourceLimits = {
+          NumberOfFiles = 8192;
+          ResidentSetSize = 2147483648; # 2GB
+        };
       };
     };
 
@@ -111,6 +123,17 @@ in
           OPENKRAKEN_CONFIG = "${cfg.orchestrator.configDir}/config.yaml";
           EGRESS_GATEWAY_PORT = toString cfg.gateway.port;
           EGRESS_SOCKET_PATH = cfg.gateway.socketPath;
+        };
+
+        # INFRA-018: Resource Limits
+        # Gateway is lightweight - lower limits than orchestrator
+        SoftResourceLimits = {
+          NumberOfFiles = 8192;
+          ResidentSetSize = 1073741824; # 1GB
+        };
+        HardResourceLimits = {
+          NumberOfFiles = 8192;
+          ResidentSetSize = 1073741824; # 1GB
         };
       };
     };

--- a/nix/nixos-modules/openkraken.nix
+++ b/nix/nixos-modules/openkraken.nix
@@ -159,6 +159,15 @@ in
         ExecStart = "${cfg.orchestrator.package}/bin/openkraken";
         PrivateTmp = true;
         NoNewPrivileges = true;
+
+        # INFRA-018: Resource Limits
+        # Per Tasks.md: Ensure stable operation under load
+        LimitNOFILE = 8192;
+        MemoryMax = "2G";
+        MemoryHigh = "1.5G";
+        CPUQuota = "80%";
+        TimeoutStartSec = "60s";
+        TimeoutStopSec = "30s";
       };
     };
 
@@ -187,6 +196,13 @@ in
         ExecStart = "${cfg.gateway.package}/bin/egress-gateway";
         PrivateTmp = true;
         NoNewPrivileges = true;
+
+        # INFRA-018: Resource Limits
+        # Gateway is lightweight - lower limits than orchestrator
+        LimitNOFILE = 8192;
+        MemoryMax = "1G";
+        MemoryHigh = "800M";
+        CPUQuota = "50%";
       };
     };
   };


### PR DESCRIPTION
## Summary

Implements INFRA-018: Resource Limits (ulimits) for OpenKraken services on both NixOS (systemd) and macOS (launchd) platforms.

### Changes

**NixOS Module (`nix/nixos-modules/openkraken.nix`)**
- Added resource limits to `openkraken-orchestrator` service:
  - `LimitNOFILE = 8192`
  - `MemoryMax = "2G"`, `MemoryHigh = "1.5G"`
  - `CPUQuota = "80%"`
  - `TimeoutStartSec = "60s"`, `TimeoutStopSec = "30s"`
- Added resource limits to `openkraken-egress-gateway` service:
  - `LimitNOFILE = 8192`
  - `MemoryMax = "1G"`, `MemoryHigh = "800M"`
  - `CPUQuota = "50%"`

**Darwin Module (`nix/darwin-modules/openkraken.nix`)**
- Added resource limits to `openkraken-orchestrator` agent:
  - `NumberOfFiles = 8192`
  - `ResidentSetSize = 2147483648` (2GB)
- Added resource limits to `openkraken-egress-gateway` agent:
  - `NumberOfFiles = 8192`
  - `ResidentSetSize = 1073741824` (1GB)

**Documentation (`Tasks.md`)**
- Fixed incorrect launchd key name: `MemorySize` → `ResidentSetSize`

### Notes

- CPU quotas (`CPUQuota`) are Linux cgroups features and are not supported by macOS launchd
- Memory limits on macOS use `ResidentSetSize` which corresponds to RLIMIT_AS
- All platforms (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin) verified with `nix flake check --all-systems`

Closes: #19
